### PR TITLE
Enable default deletion protection for RDS resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -61,12 +61,6 @@ resource "aws_db_instance" "main" {
   db_subnet_group_name = "${var.name_prefix}-subnet-group"
 
   tags = merge(var.tags, { "Name" = "${var.name_prefix}-db" })
-
-  lifecycle {
-    ignore_changes = [
-      deletion_protection
-    ]
-  }
 }
 
 resource "aws_db_subnet_group" "main" {

--- a/main.tf
+++ b/main.tf
@@ -61,6 +61,12 @@ resource "aws_db_instance" "main" {
   db_subnet_group_name = "${var.name_prefix}-subnet-group"
 
   tags = merge(var.tags, { "Name" = "${var.name_prefix}-db" })
+
+  lifecycle {
+    ignore_changes = [
+      deletion_protection
+    ]
+  }
 }
 
 resource "aws_db_subnet_group" "main" {

--- a/variables.tf
+++ b/variables.tf
@@ -42,7 +42,7 @@ variable "database_name" {
 variable "deletion_protection" {
   description = "If the DB instance should have deletion protection enabled. The database can't be deleted when this value is set to true."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "port" {


### PR DESCRIPTION
Set deletion protection to true in order to safeguard against accidental deletion of databases when running terraform in automated pipeline. This may occur if code is pushed or merged by mistake.

This change reduces risk by making the deletion of databases an explicit operation where the deletion protection either is disabled when creating the database or disabled manually after creation.