### PR TITLE
Use db_name instead of name in outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -48,5 +48,5 @@ output "username" {
 
 output "database_name" {
   description = "The database name."
-  value       = aws_db_instance.main.name
+  value       = aws_db_instance.main.db_name
 }


### PR DESCRIPTION
`name` is deprecated:
```
╷
│ Warning: Deprecated attribute
│
│   on .terraform/modules/app.database/outputs.tf line 51, in output "database_name":
│   51:   value       = aws_db_instance.main.name
│
│ The attribute "name" is deprecated. Refer to the provider documentation for details.
│
│ (and one more similar warning elsewhere)
╵
```