### PR TITLE
Replace usage of removed attribute name on aws_db_instance resource

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -48,5 +48,5 @@ output "username" {
 
 output "database_name" {
   description = "The database name."
-  value       = aws_db_instance.main.name
+  value       = aws_db_instance.main.db_name
 }


### PR DESCRIPTION
`name` har blitt fjernet til fordel for `db_name` argumentet. Dette ble forsøkt fikset tidligere i [denne commiten](https://github.com/nsbno/terraform-aws-rds-instance/commit/64826aa06ae4bf07a989d0777807e9585be395f9), men nå er det attribute og ikke argument